### PR TITLE
薬とサプリの削除機能

### DIFF
--- a/app/controllers/drugs_controller.rb
+++ b/app/controllers/drugs_controller.rb
@@ -15,6 +15,13 @@ class DrugsController < ApplicationController
   end
 
   def destroy
+    @drug = current_user.drugs.find(params[:id])
+    @drug.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to drug_supplement_lists_path, notice: "お薬を削除しました。" }
+    end
   end
 
   private

--- a/app/controllers/supplements_controller.rb
+++ b/app/controllers/supplements_controller.rb
@@ -15,6 +15,13 @@ class SupplementsController < ApplicationController
   end
 
   def destroy
+    @supplement = current_user.supplements.find(params[:id])
+    @supplement.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to drug_supplement_lists_path, notice: "サプリメントを削除しました。" }
+    end
   end
 
   private

--- a/app/views/drug_supplement_lists/index.html.erb
+++ b/app/views/drug_supplement_lists/index.html.erb
@@ -22,20 +22,22 @@
 
 <h2>お薬のリスト</h2>
 <% @drugs.each do |drug| %>
-  <%= turbo_frame_tag "drug" do %>
+  <%= turbo_frame_tag dom_id(drug) do %>
     <div>
       <%= drug.drug_name %>
       <%= link_to "編集", edit_drug_path(drug) %>
+      <%= link_to "削除", drug_path(drug), data: { turbo_stream: true, turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
     </div>
   <% end %>
 <% end %>
 
 <h2>サプリメントのリスト</h2>
 <% @supplements.each do |supplement| %>
-  <%= turbo_frame_tag "supplement" do %>
+  <%= turbo_frame_tag dom_id(supplement) do %>
     <div>
       <%= supplement.supplement_name %>
       <%= link_to "編集", edit_supplement_path(supplement) %>
+      <%= link_to "削除", supplement_path(supplement), data: { turbo_stream: true, turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/drugs/destroy.html.erb
+++ b/app/views/drugs/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Drugs#destroy</h1>
-<p>Find me in app/views/drugs/destroy.html.erb</p>

--- a/app/views/drugs/destroy.turbo_stream.erb
+++ b/app/views/drugs/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @drug %>

--- a/app/views/drugs/edit.html.erb
+++ b/app/views/drugs/edit.html.erb
@@ -1,5 +1,5 @@
 <!-- お薬編集フォーム-->
-<%= turbo_frame_tag "drug" do %>
+<%= turbo_frame_tag dom_id(drug) do %>
   <%= form_with model: @drug do |f| %>
     <div>
       <% if @drug.errors.any? %>

--- a/app/views/supplements/destroy.html.erb
+++ b/app/views/supplements/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Supplements#destroy</h1>
-<p>Find me in app/views/supplements/destroy.html.erb</p>

--- a/app/views/supplements/destroy.turbo_stream.erb
+++ b/app/views/supplements/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @supplement %>

--- a/app/views/supplements/edit.html.erb
+++ b/app/views/supplements/edit.html.erb
@@ -1,5 +1,5 @@
 <!-- サプリ編集フォーム-->
-<%= turbo_frame_tag "supplement" do %>
+<%= turbo_frame_tag dom_id(supplement) do %>
   <%= form_with model: @supplement do |f| %>
     <div>
       <% if @supplement.errors.any? %>


### PR DESCRIPTION
Close #21 #24
***
### ◆ 概要
登録済みの薬とサプリが非同期通信（Turbo railsのStreams使用）で削除できるよう実装。

### ◆ 薬
- [x] app/views/drug_supplement_lists/index.html.erbに削除ボタンの設置（link_to使用）
- [x] app/views/drugs/destroy.turbo_stream.erbの生成
- [x] app/views/drugs/destroy.html.erbの削除
- [x] app/controllers/drugs_controller.rbのdestroyアクションにて削除処理の記載
- [x] app/controllers/drugs_controller.rbのdestroyアクションにて非Turbo対応のブラウザ用にHTMLレスポンスを定義

### ◆ サプリ
- [x] app/views/drug_supplement_lists/index.html.erbに削除ボタンの設置（link_to使用）
- [x] app/views/supplements/destroy.turbo_stream.erbの生成
- [x] app/views/supplements/destroy.html.erbの削除
- [x] app/controllers/supplements_controller.rbのdestroyアクションにて削除処理の記載
- [x] app/controllers/supplements_controller.rbのdestroyアクションにて非Turbo対応のブラウザ用にHTMLレスポンスを定義