### PR TITLE
症状リストの登録機能

### DIFF
--- a/app/controllers/drug_supplement_lists_controller.rb
+++ b/app/controllers/drug_supplement_lists_controller.rb
@@ -3,8 +3,8 @@ class DrugSupplementListsController < ApplicationController
     # Formオブジェクトを使用してフォームを表示
     @drug_supplement_form = DrugSupplementForm.new
     # 一覧表示
-    @drugs = current_user.drugs
-    @supplements = current_user.supplements
+    @drugs = current_user.drugs.all
+    @supplements = current_user.supplements.all
   end
 
   def create

--- a/app/controllers/drugs_controller.rb
+++ b/app/controllers/drugs_controller.rb
@@ -11,6 +11,7 @@ class DrugsController < ApplicationController
       redirect_to drug_supplement_lists_path
     else
       render :edit, status: :unprocessable_entity
+      flash[:alert] = "症状の登録に失敗しました。入力内容を確認してください。"
     end
   end
 

--- a/app/controllers/symptoms_controller.rb
+++ b/app/controllers/symptoms_controller.rb
@@ -18,7 +18,7 @@ class SymptomsController < ApplicationController
   end
 
   def create
-    symptom_names = params[ :symptom ][ :symptom_name ]
+    symptom_names = params[:symptom][:symptom_name]
 
     if Symptom.symptom_save(current_user, symptom_names)
       redirect_to symptoms_path, notice: "症状を登録しました。"

--- a/app/controllers/symptoms_controller.rb
+++ b/app/controllers/symptoms_controller.rb
@@ -1,0 +1,70 @@
+class SymptomsController < ApplicationController
+  before_action :set_symptom, only: %i[ show edit update destroy ]
+
+  # GET /symptoms or /symptoms.json
+  def index
+    @symptoms = Symptom.all
+  end
+
+  # GET /symptoms/1 or /symptoms/1.json
+  def show
+  end
+
+  # GET /symptoms/new
+  def new
+    @symptom = Symptom.new
+  end
+
+  # GET /symptoms/1/edit
+  def edit
+  end
+
+  # POST /symptoms or /symptoms.json
+  def create
+    @symptom = Symptom.new(symptom_params)
+
+    respond_to do |format|
+      if @symptom.save
+        format.html { redirect_to @symptom, notice: "Symptom was successfully created." }
+        format.json { render :show, status: :created, location: @symptom }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @symptom.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /symptoms/1 or /symptoms/1.json
+  def update
+    respond_to do |format|
+      if @symptom.update(symptom_params)
+        format.html { redirect_to @symptom, notice: "Symptom was successfully updated." }
+        format.json { render :show, status: :ok, location: @symptom }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @symptom.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /symptoms/1 or /symptoms/1.json
+  def destroy
+    @symptom.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to symptoms_path, status: :see_other, notice: "Symptom was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_symptom
+      @symptom = Symptom.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def symptom_params
+      params.require(:symptom).permit(:symptom_name)
+    end
+end

--- a/app/controllers/symptoms_controller.rb
+++ b/app/controllers/symptoms_controller.rb
@@ -3,34 +3,28 @@ class SymptomsController < ApplicationController
 
   # GET /symptoms or /symptoms.json
   def index
-    @symptoms = Symptom.all
+    @symptom = Symptom.new
+    @symptoms = current_user.symptoms.all
   end
 
   # GET /symptoms/1 or /symptoms/1.json
-  def show
-  end
+  def show; end
 
   # GET /symptoms/new
-  def new
-    @symptom = Symptom.new
-  end
+  def new; end
 
   # GET /symptoms/1/edit
   def edit
   end
 
-  # POST /symptoms or /symptoms.json
   def create
-    @symptom = Symptom.new(symptom_params)
+    symptom_names = params[ :symptom ][ :symptom_name ]
 
-    respond_to do |format|
-      if @symptom.save
-        format.html { redirect_to @symptom, notice: "Symptom was successfully created." }
-        format.json { render :show, status: :created, location: @symptom }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @symptom.errors, status: :unprocessable_entity }
-      end
+    if Symptom.symptom_save(current_user, symptom_names)
+      redirect_to symptoms_path, notice: "症状を登録しました。"
+    else
+      flash.now[:alert] = "登録に失敗しました。入力内容をご確認ください。"
+      render :index, status: :unprocessable_entity
     end
   end
 

--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -2,4 +2,5 @@ class Drug < ApplicationRecord
   belongs_to :user
 
   validates :drug_name, presence: true
+  validates :drug_name, uniqueness: true { scope: :user_id }
 end

--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -2,5 +2,5 @@ class Drug < ApplicationRecord
   belongs_to :user
 
   validates :drug_name, presence: true
-  validates :drug_name, uniqueness: true { scope: :user_id }
+  validates :drug_name, uniqueness: { scope: :user_id }
 end

--- a/app/models/supplement.rb
+++ b/app/models/supplement.rb
@@ -2,4 +2,5 @@ class Supplement < ApplicationRecord
   belongs_to :user
 
   validates :supplement_name, presence: true
+  validates :supplement_name, uniqueness: true { scope: :user_id }
 end

--- a/app/models/supplement.rb
+++ b/app/models/supplement.rb
@@ -2,5 +2,5 @@ class Supplement < ApplicationRecord
   belongs_to :user
 
   validates :supplement_name, presence: true
-  validates :supplement_name, uniqueness: true { scope: :user_id }
+  validates :supplement_name, uniqueness: { scope: :user_id }
 end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -2,4 +2,13 @@ class Symptom < ApplicationRecord
   belongs_to :user
 
   validates :symptom_name, presence: true
+  validates :symptom_name, uniqueness: { scope: :user_id }
+
+  def self.symptom_save(user, symptom_names)
+    return if symptom_names.nil?
+    symptoms = symptom_names.split(',').map(&:strip)
+    symptoms.each do |name|
+      user.symptoms.create(symptom_name: name)
+    end
+  end
 end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -1,0 +1,5 @@
+class Symptom < ApplicationRecord
+  belongs_to :user
+
+  validates :symptom_name, presence: true
+end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -6,7 +6,7 @@ class Symptom < ApplicationRecord
 
   def self.symptom_save(user, symptom_names)
     return if symptom_names.nil?
-    symptoms = symptom_names.split(',').map(&:strip)
+    symptoms = symptom_names.split(",").map(&:strip)
     symptoms.each do |name|
       user.symptoms.create(symptom_name: name)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :drugs
   has_many :supplements
+  has_many :symptoms
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,6 +17,9 @@
           <li>
             <%= link_to "お薬とサプリ", drug_supplement_lists_index_path %>
           </li>
+          <li>
+            <%= link_to "症状リスト", symptoms_path %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/symptoms/_form.html.erb
+++ b/app/views/symptoms/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: symptom) do |form| %>
+  <% if symptom.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(symptom.errors.count, "error") %> prohibited this symptom from being saved:</h2>
+
+      <ul>
+        <% symptom.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :symptom_name, style: "display: block" %>
+    <%= form.text_field :symptom_name %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/symptoms/_symptom.html.erb
+++ b/app/views/symptoms/_symptom.html.erb
@@ -1,0 +1,7 @@
+<div id="<%= dom_id symptom %>">
+  <p>
+    <strong>Symptom name:</strong>
+    <%= symptom.symptom_name %>
+  </p>
+
+</div>

--- a/app/views/symptoms/_symptom.html.erb
+++ b/app/views/symptoms/_symptom.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id symptom %>">
   <p>
-    <strong>Symptom name:</strong>
+    <strong>症状</strong>
     <%= symptom.symptom_name %>
   </p>
 

--- a/app/views/symptoms/_symptom.json.jbuilder
+++ b/app/views/symptoms/_symptom.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! symptom, :id, :symptom_name, :created_at, :updated_at
+json.url symptom_url(symptom, format: :json)

--- a/app/views/symptoms/edit.html.erb
+++ b/app/views/symptoms/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Editing symptom" %>
+
+<h1>Editing symptom</h1>
+
+<%= render "form", symptom: @symptom %>
+
+<br>
+
+<div>
+  <%= link_to "Show this symptom", @symptom %> |
+  <%= link_to "Back to symptoms", symptoms_path %>
+</div>

--- a/app/views/symptoms/index.html.erb
+++ b/app/views/symptoms/index.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Symptoms" %>
+
+<h1>Symptoms</h1>
+
+<div id="symptoms">
+  <% @symptoms.each do |symptom| %>
+    <%= render symptom %>
+    <p>
+      <%= link_to "Show this symptom", symptom %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New symptom", new_symptom_path %>

--- a/app/views/symptoms/index.html.erb
+++ b/app/views/symptoms/index.html.erb
@@ -1,16 +1,26 @@
-<p style="color: green"><%= notice %></p>
+<!-- 症状リスト一覧ページ -->
+
+<%= form_with model: @symptom, local: true do |f| %>
+  <div>
+    <%= f.label :symptom_name, "症状を新しく追加する" %><br>
+    <%= f.text_field :symptom_name, placeholder: "症状をカンマ(,)区切りで複数登録できます。" %><br>
+  </div>
+  <br>
+  <div>
+    <%= f.submit "登録" %>
+  </div>
+<% end %>
+
+<br>
+<br>
+<br>
 
 <% content_for :title, "Symptoms" %>
 
-<h1>Symptoms</h1>
-
-<div id="symptoms">
+<h1>症状リスト</h1>
+<br>
   <% @symptoms.each do |symptom| %>
-    <%= render symptom %>
-    <p>
-      <%= link_to "Show this symptom", symptom %>
-    </p>
+    <div>
+      <%= symptom.symptom_name %>
+    </div>
   <% end %>
-</div>
-
-<%= link_to "New symptom", new_symptom_path %>

--- a/app/views/symptoms/index.json.jbuilder
+++ b/app/views/symptoms/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @symptoms, partial: "symptoms/symptom", as: :symptom

--- a/app/views/symptoms/new.html.erb
+++ b/app/views/symptoms/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "New symptom" %>
+
+<h1>New symptom</h1>
+
+<%= render "form", symptom: @symptom %>
+
+<br>
+
+<div>
+  <%= link_to "Back to symptoms", symptoms_path %>
+</div>

--- a/app/views/symptoms/show.html.erb
+++ b/app/views/symptoms/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @symptom %>
+
+<div>
+  <%= link_to "Edit this symptom", edit_symptom_path(@symptom) %> |
+  <%= link_to "Back to symptoms", symptoms_path %>
+
+  <%= button_to "Destroy this symptom", @symptom, method: :delete %>
+</div>

--- a/app/views/symptoms/show.json.jbuilder
+++ b/app/views/symptoms/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "symptoms/symptom", symptom: @symptom

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :drug_supplement_lists, only: [ :index, :create ]
   resources :drugs, only: [ :edit, :update, :destroy ]
   resources :supplements, only: [ :edit, :update, :destroy ]
+  resources :symptoms
   # ログアウト後トップページに遷移
   devise_scope :user do
     get "/users/sign_out" => "devise/sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :symptoms
   # Reveal health status on /up
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/db/migrate/20241222134244_create_symptoms.rb
+++ b/db/migrate/20241222134244_create_symptoms.rb
@@ -1,0 +1,10 @@
+class CreateSymptoms < ActiveRecord::Migration[7.2]
+  def change
+    create_table :symptoms do |t|
+      t.string :symptom_name, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_053949) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_22_134244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_053949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_supplements_on_user_id"
+  end
+
+  create_table "symptoms", force: :cascade do |t|
+    t.string "symptom_name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_symptoms_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -50,4 +58,5 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_053949) do
 
   add_foreign_key "drugs", "users"
   add_foreign_key "supplements", "users"
+  add_foreign_key "symptoms", "users"
 end


### PR DESCRIPTION
Close #25
***
### ◆ 概要
症状のリストが登録できるように実装

- [x] Symptomsテーブルの作成
- [x] 入力フォーム（app/views/symptoms/index.html.erb）から半角カンマ区切りで複数登録できるよう、app/models/symptom.rbにクラスメソッド（self.symptom_save）を定義しコントローラがなるべくシンプルになるよう務めた。

[![Image from Gyazo](https://i.gyazo.com/64036f5ba36ed9747e25df0aaef870f2.png)](https://gyazo.com/64036f5ba36ed9747e25df0aaef870f2)

### ◆ 動作確認
DBには問題なく保存されている。
[![Image from Gyazo](https://i.gyazo.com/b63025f15b743cf696f77805e6eafc21.png)](https://gyazo.com/b63025f15b743cf696f77805e6eafc21)

未入力で登録しようとした時と、同名のデータを登録しようとした際（バリデーションに弾かれた際）に表示されるフラッシュメッセージが登録成功時のメッセージが表示されてしまっているため、本リリース時に修正が必要。
#68 