### PR TITLE
排便登録機能の実装

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,6 +1,4 @@
 class RecordsController < ApplicationController
-  before_action :record_string, only: [:create, :update]
-
   def new
     @record = Record.new
   end
@@ -45,11 +43,14 @@ class RecordsController < ApplicationController
   private
 
   def record_params
-    params.require(:record).permit(:record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary, :poop_memo, defecation: [], poop_amount: [], poop_shape: [])
-    .merge(user_id: current_user.id)
-  end
-
-  def record_string
-    params[:record][:defecation][:poop_amount][:poop_shape] = params[:record][:defecation][:poop_amount][:poop_shape].join("/")
+    params.require(:record).permit(
+      :record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating,
+      :food, :meal_memo, :diary, :poop_memo, defecation: [], poop_amount: [], poop_shape: []
+    ).tap do |whitelisted|
+      # 配列をカンマ区切りの文字列に変換（reject(&:blank?)はnil対策）
+      whitelisted[:defecation] = whitelisted[:defecation].reject(&:blank?).join(",") if whitelisted[:defecation].is_a?(Array)
+      whitelisted[:poop_amount] = whitelisted[:poop_amount].reject(&:blank?).join(",") if whitelisted[:poop_amount].is_a?(Array)
+      whitelisted[:poop_shape] = whitelisted[:poop_shape].reject(&:blank?).join(",") if whitelisted[:poop_shape].is_a?(Array)
+    end
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,4 +1,6 @@
 class RecordsController < ApplicationController
+  before_action :record_string, only: [:create, :update]
+
   def new
     @record = Record.new
   end
@@ -43,7 +45,11 @@ class RecordsController < ApplicationController
   private
 
   def record_params
-    params.require(:record).permit(:record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary)
+    params.require(:record).permit(:record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary, :poop_memo, defecation: [], poop_amount: [], poop_shape: [])
     .merge(user_id: current_user.id)
+  end
+
+  def record_string
+    params[:record][:defecation][:poop_amount][:poop_shape] = params[:record][:defecation][:poop_amount][:poop_shape].join("/")
   end
 end

--- a/app/views/main/_records.html.erb
+++ b/app/views/main/_records.html.erb
@@ -27,6 +27,16 @@
             <div class="border-t border-gray-300 my-5"></div>
             <li><%= record.meal_memo %></li>
           </div>
+
+          <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-10 rounded-md text-left">
+            <li class="font-bold mb-5">うんち</li>
+            <li>いつ：<%= record.defecation %></li>
+            <li>かたち：<%= record.poop_shape %></li>
+            <li>量：<%= record.poop_amount %></li>
+            <div class="border-t border-gray-300 my-5"></div>
+            <li><%= record.poop_memo %></li>
+          </div>
+
         </ul>
       </div>
     </div>

--- a/app/views/main/_records.html.erb
+++ b/app/views/main/_records.html.erb
@@ -22,19 +22,19 @@
           <li class="my-12"><%= record.diary %></li>
 
           <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-10 rounded-md text-left">
-            <li class="font-bold mb-5">食事</li>
-            <li><%= record.food %></li>
+            <li class="font-bold mb-5">食 事</li>
+            <li class="text-xs"><%= record.food %></li>
             <div class="border-t border-gray-300 my-5"></div>
-            <li><%= record.meal_memo %></li>
+            <li class="text-xs"><%= record.meal_memo %></li>
           </div>
 
-          <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-10 rounded-md text-left">
-            <li class="font-bold mb-5">うんち</li>
-            <li>いつ：<%= record.defecation %></li>
-            <li>かたち：<%= record.poop_shape %></li>
-            <li>量：<%= record.poop_amount %></li>
+          <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-5 rounded-md text-left">
+            <li class="font-bold mb-5">排 便</li>
+            <li class="text-xs mb-4">時間： <%= record.defecation.presence&.split(",")&.join("，") %></li>
+            <li class="text-xs mb-4">形状： <%= record.poop_shape.presence&.split(",")&.join("，") %></li>
+            <li class="text-xs">分量： <%= record.poop_amount.presence&.split(",")&.join("，") %></li>
             <div class="border-t border-gray-300 my-5"></div>
-            <li><%= record.poop_memo %></li>
+            <li class="text-xs"><%= record.poop_memo %></li>
           </div>
 
         </ul>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -16,17 +16,18 @@
   <% end %>
 
   <%= form_with model: @record, url: user_records_path(current_user), local: true do |f| %>
-    <div class="flex justify-center mb-8">
+    <div class="flex justify-center mb-5">
       <%= f.date_select :record_date %>の記録
     </div>
 
     <div class="flex justify-center w-full mb-32">
       <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
         <div class="card-body">
-          <p class="font-bold">う ん ち</p>
+          <p class="font-bold">排 便</p>
           <div class="border-t border-gray-300 mb-8"></div>
 
-          <p class="font-bold text-xs text-center mb-3">総合評価</p>
+          <p class="font-bold text-xs text-center">排便総合評価</p>
+          <p class="text-xs text-center mb-2">（グラフに反映されます）</p>
           <div class="rating flex justify-center items-center">
             <%= f.label :poop_rating, "評価しない", for: "poop_rating_0", class: "text-xs" %>
             <%= f.radio_button :poop_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "poop_rating_0", checked: true %>
@@ -42,24 +43,11 @@
               <%= f.label :defecation, "排便の有無", class: "font-bold" %>
             </div>
             <div class="flex justify-center flex-wrap gap-3">
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "朝", nil %> 朝
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "午前中", nil %> 午前中
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "昼", nil %> 昼
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "夕方", nil %> 夕方
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "夜", nil %> 夜
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "出なかった", nil %> 出なかった
-              </div>
+              <%= f.collection_check_boxes :defecation, ["朝", "午前中", "昼", "夕方", "夜", "出なかった"], :to_s, :to_s do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -68,15 +56,11 @@
               <%= f.label :poop_amount, "うんちの量", class: "font-bold" %>
             </div>
             <div class="flex justify-center flex-wrap gap-3">
-              <div class="flex items-center">
-                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "すっきり！", nil %> すっきり！
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "いつも通り", nil %> いつも通り
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "残っている感じがする", nil %> 残っている感じがする
-              </div>
+              <%= f.collection_check_boxes :poop_amount, ["すっきり！", "いつも通り", "少しだけ", "残便感あり"], :to_s, :to_s do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -85,36 +69,11 @@
               <%= f.label :poop_shape, "うんちの形状", class: "font-bold" %>
             </div>
             <div class="flex justify-center flex-wrap gap-3">
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "バナナ状", nil %> バナナ状
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "かちこち", nil %> かちこち
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ころころ", nil %> ころころ
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ゆるめ", nil %> ゆるめ
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "脂肪便", nil %> 脂肪便
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "下痢", nil %> 下痢
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ほぼ水", nil %> ほぼ水
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "粘液状", nil %> 粘液状
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "タール便", nil %> タール便
-              </div>
-              <div class="flex items-center">
-                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "血便", nil %> 血便
-              </div>
+              <%= f.collection_check_boxes :poop_shape, ["バナナ", "かちこち", "コロコロ", "ゆるめ", "下痢", "ほぼ水", "粘液状", "脂肪便", "タール便", "血便"], :to_s, :to_s do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
             </div>
           </div>
 

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -2,7 +2,7 @@
 <div class="border-t border-gray-900 mb-12 mt-1"></div>
 
 <div class="flex flex-col items-center w-full">
-  <p class="text-xs mx-4 mb-12 text-left">すでに登録のある日付の記録はできませんのでご注意ください。</p>
+  <p class="text-xs mx-4 mb-24 text-left">すでに登録のある日付の記録はできませんのでご注意ください。</p>
 
   <% if @record.errors.any? %>
     <div class="text-red-500 text-xs text-left ml-4 mb-5">
@@ -16,19 +16,116 @@
   <% end %>
 
   <%= form_with model: @record, url: user_records_path(current_user), local: true do |f| %>
-    <div class="flex justify-center mb-16">
+    <div class="flex justify-center mb-8">
       <%= f.date_select :record_date %>の記録
     </div>
 
-    <div class="divider text-xs">排  便</div>
-    <div class="rating flex justify-center items-center">
-      <%= f.label :poop_rating, "評価しない", for: "poop_rating_0", class: "text-xs" %>
-      <%= f.radio_button :poop_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "poop_rating_0", checked: true %>
-      <%= f.radio_button :poop_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_1" %>
-      <%= f.radio_button :poop_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_2" %>
-      <%= f.radio_button :poop_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_3" %>
-      <%= f.radio_button :poop_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_4" %>
-      <%= f.radio_button :poop_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_5" %>
+    <div class="flex justify-center w-full mb-32">
+      <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
+        <div class="card-body">
+          <p class="font-bold">う ん ち</p>
+          <div class="border-t border-gray-300 mb-8"></div>
+
+          <p class="font-bold text-xs text-center mb-3">総合評価</p>
+          <div class="rating flex justify-center items-center">
+            <%= f.label :poop_rating, "評価しない", for: "poop_rating_0", class: "text-xs" %>
+            <%= f.radio_button :poop_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "poop_rating_0", checked: true %>
+            <%= f.radio_button :poop_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_1" %>
+            <%= f.radio_button :poop_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_2" %>
+            <%= f.radio_button :poop_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_3" %>
+            <%= f.radio_button :poop_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_4" %>
+            <%= f.radio_button :poop_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_5" %>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :defecation, "排便の有無", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "朝", nil %> 朝
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "午前中", nil %> 午前中
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "昼", nil %> 昼
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "夕方", nil %> 夕方
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "夜", nil %> 夜
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :defecation, { multiple: true, class: "mr-1" }, "出なかった", nil %> 出なかった
+              </div>
+            </div>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :poop_amount, "うんちの量", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <div class="flex items-center">
+                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "すっきり！", nil %> すっきり！
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "いつも通り", nil %> いつも通り
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_amount, { multiple: true, class: "mr-1" }, "残っている感じがする", nil %> 残っている感じがする
+              </div>
+            </div>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :poop_shape, "うんちの形状", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "バナナ状", nil %> バナナ状
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "かちこち", nil %> かちこち
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ころころ", nil %> ころころ
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ゆるめ", nil %> ゆるめ
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "脂肪便", nil %> 脂肪便
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "下痢", nil %> 下痢
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "ほぼ水", nil %> ほぼ水
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "粘液状", nil %> 粘液状
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "タール便", nil %> タール便
+              </div>
+              <div class="flex items-center">
+                <%= f.check_box :poop_shape, { multiple: true, class: "mr-1" }, "血便", nil %> 血便
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-12 mb-8 w-full flex justify-center">
+            <div class="w-full">
+              <%= f.label :poop_memo, "うんちメモ", class: "font-bold text-xs block mb-2 text-left" %>
+              <%= f.text_field :poop_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "うんちメモ" %>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="divider text-xs mt-20">消化器官</div>

--- a/db/migrate/20250218044311_add_poop_attributes_to_records.rb
+++ b/db/migrate/20250218044311_add_poop_attributes_to_records.rb
@@ -1,0 +1,8 @@
+class AddPoopAttributesToRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :records, :defecation, :string, null: false, default: "未入力"
+    add_column :records, :poop_amount, :string, null: false, default: "未入力"
+    add_column :records, :poop_shape, :string, null: false, default: "未入力"
+    add_column :records, :poop_memo, :string
+  end
+end

--- a/db/migrate/20250219030207_change_column_type_in_records.rb
+++ b/db/migrate/20250219030207_change_column_type_in_records.rb
@@ -1,0 +1,7 @@
+class ChangeColumnTypeInRecords < ActiveRecord::Migration[7.2]
+  def change
+    change_column :records, :defecation, :text
+    change_column :records, :poop_amount, :text
+    change_column :records, :poop_shape, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_05_062445) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_030207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_05_062445) do
     t.string "food", default: "未入力", null: false
     t.string "meal_memo", default: "未入力", null: false
     t.text "diary", default: "未入力", null: false
+    t.text "defecation", default: "未入力", null: false
+    t.text "poop_amount", default: "未入力", null: false
+    t.text "poop_shape", default: "未入力", null: false
+    t.string "poop_memo"
     t.index ["user_id"], name: "index_records_on_user_id"
   end
 


### PR DESCRIPTION
Close #39
***
### ◆ 概要
- [x] Recordsテーブルにdefecation(text),poop_amount(text),poop_shape(text),poop_memo(string)カラムを追加
- [x] app/views/records/new.html.erbに排便記録入力フォームを作成（collection_check_boxesヘルパーを採用し複数選択可能なチェックボックスを作成）
- [x] app/controllers/records_controller.rbのストロングパラメータに今回追加したカラムを追加
- [x] 同じくapp/controllers/records_controller.rbのrecord_paramsメソッドに、配列ではなく文字列として保存されるようロジックを記入（collection_check_boxesヘルパーのデフォルトでは自動的に配列として保存されるがtext型のため文字列に直す必要があった）
- [x] app/views/main/_records.html.erbに登録した内容が表示されるよう実装