### PR TITLE
排便記録の編集機能を実装

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -19,6 +19,11 @@ class RecordsController < ApplicationController
 
   def edit
     @record = current_user.records.find(params[:id])
+
+    # 文字列で保存されているデータを配列に戻しインスタンス変数に格納
+    @selected_defecation = @record.defecation.present? ? @record.defecation.split("，") : []
+    @selected_poop_amount = @record.poop_amount.present? ? @record.poop_amount.split("，") : []
+    @selected_poop_shape = @record.poop_shape.present? ? @record.poop_shape.split("，") : []
   end
 
   def update
@@ -42,15 +47,15 @@ class RecordsController < ApplicationController
 
   private
 
+  # 配列のまま受け取り、ストロングパラメータの許可後に文字列に変換させる
   def record_params
     params.require(:record).permit(
-      :record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating,
-      :food, :meal_memo, :diary, :poop_memo, defecation: [], poop_amount: [], poop_shape: []
-    ).tap do |whitelisted|
-      # 配列をカンマ区切りの文字列に変換（reject(&:blank?)はnil対策）
-      whitelisted[:defecation] = whitelisted[:defecation].reject(&:blank?).join(",") if whitelisted[:defecation].is_a?(Array)
-      whitelisted[:poop_amount] = whitelisted[:poop_amount].reject(&:blank?).join(",") if whitelisted[:poop_amount].is_a?(Array)
-      whitelisted[:poop_shape] = whitelisted[:poop_shape].reject(&:blank?).join(",") if whitelisted[:poop_shape].is_a?(Array)
+      :record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary, :poop_memo,
+      defecation: [], poop_amount: [], poop_shape: []
+    ).tap do |params|
+      params[:defecation] = params[:defecation].reject(&:blank?).join("，") if params[:defecation].is_a?(Array)
+      params[:poop_amount] = params[:poop_amount].reject(&:blank?).join("，") if params[:poop_amount].is_a?(Array)
+      params[:poop_shape] = params[:poop_shape].reject(&:blank?).join("，") if params[:poop_shape].is_a?(Array)
     end
   end
 end

--- a/app/views/main/_records.html.erb
+++ b/app/views/main/_records.html.erb
@@ -30,9 +30,9 @@
 
           <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-5 rounded-md text-left">
             <li class="font-bold mb-5">排 便</li>
-            <li class="text-xs mb-4">時間： <%= record.defecation.presence&.split(",")&.join("，") %></li>
-            <li class="text-xs mb-4">形状： <%= record.poop_shape.presence&.split(",")&.join("，") %></li>
-            <li class="text-xs">分量： <%= record.poop_amount.presence&.split(",")&.join("，") %></li>
+            <li class="text-xs mb-4">時間： <%= record.defecation %></li>
+            <li class="text-xs mb-4">形状： <%= record.poop_shape %></li>
+            <li class="text-xs">分量： <%= record.poop_amount %></li>
             <div class="border-t border-gray-300 my-5"></div>
             <li class="text-xs"><%= record.poop_memo %></li>
           </div>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -8,15 +8,71 @@
       <%= f.date_select :record_date %>の記録
     </div>
 
-    <div class="divider text-xs">排  便</div>
-    <div class="rating flex justify-center items-center">
-      <%= f.label :poop_rating, "評価しない", for: "poop_rating_0", class: "text-xs" %>
-      <%= f.radio_button :poop_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "poop_rating_0", checked: true %>
-      <%= f.radio_button :poop_rating, 1, class: "mask mask-star-2 bg-ginkgo-500", id: "poop_rating_1" %>
-      <%= f.radio_button :poop_rating, 2, class: "mask mask-star-2 bg-ginkgo-500", id: "poop_rating_2" %>
-      <%= f.radio_button :poop_rating, 3, class: "mask mask-star-2 bg-ginkgo-500", id: "poop_rating_3" %>
-      <%= f.radio_button :poop_rating, 4, class: "mask mask-star-2 bg-ginkgo-500", id: "poop_rating_4" %>
-      <%= f.radio_button :poop_rating, 5, class: "mask mask-star-2 bg-ginkgo-500", id: "poop_rating_5" %>
+    <div class="flex justify-center w-full mb-32">
+      <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
+        <div class="card-body">
+          <p class="font-bold">排 便</p>
+          <div class="border-t border-gray-300 mb-8"></div>
+
+          <p class="font-bold text-xs text-center">排便総合評価</p>
+          <p class="text-xs text-center mb-2">（グラフに反映されます）</p>
+          <div class="rating flex justify-center items-center">
+            <%= f.label :poop_rating, "評価しない", for: "poop_rating_0", class: "text-xs" %>
+            <%= f.radio_button :poop_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "poop_rating_0", checked: true %>
+            <%= f.radio_button :poop_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_1" %>
+            <%= f.radio_button :poop_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_2" %>
+            <%= f.radio_button :poop_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_3" %>
+            <%= f.radio_button :poop_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_4" %>
+            <%= f.radio_button :poop_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "poop_rating_5" %>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :defecation, "排便の有無", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <%= f.collection_check_boxes :defecation, ["朝", "午前中", "昼", "夕方", "夜", "出なかった"], :to_s, :to_s, checked: @selected_defecation do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :poop_amount, "うんちの量", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <%= f.collection_check_boxes :poop_amount, ["すっきり！", "いつも通り", "少しだけ", "残便感あり"], :to_s, :to_s, checked: @selected_poop_amount do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :poop_shape, "うんちの形状", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <%= f.collection_check_boxes :poop_shape, ["バナナ", "かちこち", "コロコロ", "ゆるめ", "下痢", "ほぼ水", "粘液状", "脂肪便", "タール便", "血便"], :to_s, :to_s, checked: @selected_poop_shape do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="mt-12 mb-8 w-full flex justify-center">
+            <div class="w-full">
+              <%= f.label :poop_memo, "うんちメモ", class: "font-bold text-xs block mb-2 text-left" %>
+              <%= f.text_field :poop_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "うんちメモ" %>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="divider text-xs mt-20">消化器官</div>


### PR DESCRIPTION
Close #40
***
### ◆ 概要
- [x] 編集ページ（app/views/records/edit.html.erb）のチェックボックスに既存データを反映させるため、app/controllers/records_controller.rbのeditアクションに、文字列→配列に戻すロジックを追加（インスタンス変数に格納）
- [x] 編集ページ（app/views/records/edit.html.erb）のcollection_check_boxesヘルパーの引数に上記のメソッドを渡し、編集ページに遷移した際にデータが反映されるよう実装