### PR TITLE
消化器官記録の登録、編集機能の実装

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -24,6 +24,7 @@ class RecordsController < ApplicationController
     @selected_defecation = @record.defecation.present? ? @record.defecation.split("，") : []
     @selected_poop_amount = @record.poop_amount.present? ? @record.poop_amount.split("，") : []
     @selected_poop_shape = @record.poop_shape.present? ? @record.poop_shape.split("，") : []
+    @selected_belly_condition = @record.belly_condition.present? ? @record.belly_condition.split("，") : []
   end
 
   def update
@@ -50,12 +51,13 @@ class RecordsController < ApplicationController
   # 配列のまま受け取り、ストロングパラメータの許可後に文字列に変換させる
   def record_params
     params.require(:record).permit(
-      :record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary, :poop_memo,
-      defecation: [], poop_amount: [], poop_shape: []
+      :record_date, :poop_rating, :belly_rating, :meal_rating, :condition_rating, :food, :meal_memo, :diary, :poop_memo, :belly_memo,
+      defecation: [], poop_amount: [], poop_shape: [], belly_condition: []
     ).tap do |params|
       params[:defecation] = params[:defecation].reject(&:blank?).join("，") if params[:defecation].is_a?(Array)
       params[:poop_amount] = params[:poop_amount].reject(&:blank?).join("，") if params[:poop_amount].is_a?(Array)
       params[:poop_shape] = params[:poop_shape].reject(&:blank?).join("，") if params[:poop_shape].is_a?(Array)
+      params[:belly_condition] = params[:belly_condition].reject(&:blank?).join("，") if params[:belly_condition].is_a?(Array)
     end
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -2,7 +2,7 @@ class Record < ApplicationRecord
   belongs_to :user
 
   validates :condition_rating, :belly_rating, :meal_rating, :poop_rating, inclusion: { in: 0..5 }
-  validates :food, :meal_memo, length: { maximum: 255 }
+  validates :food, :meal_memo, :poop_memo, :belly_memo, length: { maximum: 255 }
   validates :record_date, presence: true
 
   validate :unique_record_date, on: :create

--- a/app/views/main/_records.html.erb
+++ b/app/views/main/_records.html.erb
@@ -22,6 +22,13 @@
           <li class="my-12"><%= record.diary %></li>
 
           <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-10 rounded-md text-left">
+            <li class="font-bold mb-5">消 化 器 官</li>
+            <li class="text-xs"><%= record.belly_condition %></li>
+            <div class="border-t border-gray-300 my-5"></div>
+            <li class="text-xs"><%= record.belly_memo %></li>
+          </div>
+
+          <div class="card card-compact bg-base-100 w-full h-auto px-4 py-3.5 mt-5 rounded-md text-left">
             <li class="font-bold mb-5">食 事</li>
             <li class="text-xs"><%= record.food %></li>
             <div class="border-t border-gray-300 my-5"></div>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -4,11 +4,12 @@
 <div class="flex flex-col items-center w-full">
 
   <%= form_with model: @record, url: user_record_path(current_user), local: true do |f| %>
-    <div class="flex justify-center mb-16">
+    <div class="flex justify-center mb-5">
       <%= f.date_select :record_date %>の記録
     </div>
 
-    <div class="flex justify-center w-full mb-32">
+<!-- 排便 -->
+    <div class="flex justify-center w-full mb-10">
       <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
         <div class="card-body">
           <p class="font-bold">排 便</p>
@@ -75,15 +76,47 @@
       </div>
     </div>
 
-    <div class="divider text-xs mt-20">消化器官</div>
-    <div class="rating flex justify-center items-center">
-      <%= f.label :belly_rating, "評価しない", for: "belly_rating_0", class: "text-xs" %>
-      <%= f.radio_button :belly_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "belly_rating_0", checked: true %>
-      <%= f.radio_button :belly_rating, 1, class: "mask mask-star-2 bg-ginkgo-500", id: "belly_rating_1" %>
-      <%= f.radio_button :belly_rating, 2, class: "mask mask-star-2 bg-ginkgo-500", id: "belly_rating_2" %>
-      <%= f.radio_button :belly_rating, 3, class: "mask mask-star-2 bg-ginkgo-500", id: "belly_rating_3" %>
-      <%= f.radio_button :belly_rating, 4, class: "mask mask-star-2 bg-ginkgo-500", id: "belly_rating_4" %>
-      <%= f.radio_button :belly_rating, 5, class: "mask mask-star-2 bg-ginkgo-500", id: "belly_rating_5" %>
+<!-- 消化器官 -->
+    <div class="flex justify-center w-full mb-10">
+      <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
+        <div class="card-body">
+          <p class="font-bold">消 化 器 官</p>
+          <div class="border-t border-gray-300 mb-8"></div>
+
+          <p class="font-bold text-xs text-center">消化器官総合評価</p>
+          <p class="text-xs text-center mb-2">（グラフに反映されます）</p>
+          <div class="rating flex justify-center items-center">
+            <%= f.label :belly_rating, "評価しない", for: "belly_rating_0", class: "text-xs" %>
+            <%= f.radio_button :belly_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "belly_rating_0", checked: true %>
+            <%= f.radio_button :belly_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_1" %>
+            <%= f.radio_button :belly_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_2" %>
+            <%= f.radio_button :belly_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_3" %>
+            <%= f.radio_button :belly_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_4" %>
+            <%= f.radio_button :belly_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_5" %>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :belly_condition, "症状", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <%= f.collection_check_boxes :belly_condition, ["腹痛", "げっぷ", "おなら", "膨満感", "腹鳴", "胸焼け", "吐き気", "嘔吐", "胃酸逆流", "その他"], :to_s, :to_s, checked: @selected_belly_condition do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="mt-12 mb-8 w-full flex justify-center">
+            <div class="w-full">
+              <%= f.label :belly_memo, "消化器官メモ", class: "font-bold text-xs block mb-2 text-left" %>
+              <%= f.text_field :belly_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "備考など" %>
+            </div>
+          </div>
+
+        </div>
+      </div>
     </div>
 
     <div class="divider text-xs mt-20">食  事</div>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -20,7 +20,8 @@
       <%= f.date_select :record_date %>の記録
     </div>
 
-    <div class="flex justify-center w-full mb-32">
+<!-- 排便 -->
+    <div class="flex justify-center w-full mb-10">
       <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
         <div class="card-body">
           <p class="font-bold">排 便</p>
@@ -80,24 +81,57 @@
           <div class="mt-12 mb-8 w-full flex justify-center">
             <div class="w-full">
               <%= f.label :poop_memo, "うんちメモ", class: "font-bold text-xs block mb-2 text-left" %>
-              <%= f.text_field :poop_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "うんちメモ" %>
+              <%= f.text_field :poop_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "備考など" %>
             </div>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="divider text-xs mt-20">消化器官</div>
-    <div class="rating flex justify-center items-center">
-      <%= f.label :belly_rating, "評価しない", for: "belly_rating_0", class: "text-xs" %>
-      <%= f.radio_button :belly_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "belly_rating_0", checked: true %>
-      <%= f.radio_button :belly_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_1" %>
-      <%= f.radio_button :belly_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_2" %>
-      <%= f.radio_button :belly_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_3" %>
-      <%= f.radio_button :belly_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_4" %>
-      <%= f.radio_button :belly_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_5" %>
+<!-- 消化器官 -->
+    <div class="flex justify-center w-full mb-10">
+      <div class="card card-compact bg-base-100 w-full rounded-sm shadow-md h-auto mx-4">
+        <div class="card-body">
+          <p class="font-bold">消 化 器 官</p>
+          <div class="border-t border-gray-300 mb-8"></div>
+
+          <p class="font-bold text-xs text-center">消化器官総合評価</p>
+          <p class="text-xs text-center mb-2">（グラフに反映されます）</p>
+          <div class="rating flex justify-center items-center">
+            <%= f.label :belly_rating, "評価しない", for: "belly_rating_0", class: "text-xs" %>
+            <%= f.radio_button :belly_rating, 0, class: "mask mask-star-2 bg-gray-400 mr-5", id: "belly_rating_0", checked: true %>
+            <%= f.radio_button :belly_rating, 1, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_1" %>
+            <%= f.radio_button :belly_rating, 2, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_2" %>
+            <%= f.radio_button :belly_rating, 3, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_3" %>
+            <%= f.radio_button :belly_rating, 4, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_4" %>
+            <%= f.radio_button :belly_rating, 5, class: "mask mask-star-2 bg-ginkgo-900", id: "belly_rating_5" %>
+          </div>
+
+          <div class="text-xs">
+            <div class="flex items-center mt-12 mb-5">
+              <%= f.label :belly_condition, "症状", class: "font-bold" %>
+            </div>
+            <div class="flex justify-center flex-wrap gap-3">
+              <%= f.collection_check_boxes :belly_condition, ["腹痛", "げっぷ", "おなら", "膨満感", "腹鳴", "胸焼け", "吐き気", "嘔吐", "胃酸逆流", "その他"], :to_s, :to_s do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-1") %> <%= b.text %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="mt-12 mb-8 w-full flex justify-center">
+            <div class="w-full">
+              <%= f.label :belly_memo, "消化器官メモ", class: "font-bold text-xs block mb-2 text-left" %>
+              <%= f.text_field :belly_memo, class: "textarea textarea-bordered rounded-sm w-full", placeholder: "備考など" %>
+            </div>
+          </div>
+
+        </div>
+      </div>
     </div>
 
+<!-- 食事 -->
     <div class="divider text-xs mt-20">食  事</div>
     <div class="rating flex justify-center items-center">
       <%= f.label :meal_rating, "評価しない", for: "meal_rating_0", class: "text-xs" %>

--- a/db/migrate/20250220065452_add_belly_condition_and_belly_memo_to_records.rb
+++ b/db/migrate/20250220065452_add_belly_condition_and_belly_memo_to_records.rb
@@ -1,0 +1,6 @@
+class AddBellyConditionAndBellyMemoToRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :records, :belly_condition, :text, null: false, default: "未入力"
+    add_column :records, :belly_memo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_19_030207) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_20_065452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_030207) do
     t.text "poop_amount", default: "未入力", null: false
     t.text "poop_shape", default: "未入力", null: false
     t.string "poop_memo"
+    t.text "belly_condition", default: "未入力", null: false
+    t.string "belly_memo"
     t.index ["user_id"], name: "index_records_on_user_id"
   end
 


### PR DESCRIPTION
Close #41 #45
***
### ◆ 概要
- [x] Recordsテーブルにbelly_conditionカラムとbelly_memoカラムの追加
- [x] app/views/records/new.html.erbに消化器官登録フォームの作成
- [x] app/controllers/records_controller.rbのストロングパラメータとeditアクションのロジック追加
- [x] app/models/record.rbにバリデーション追加
- [x] app/views/main/_records.html.erbに消化器官のデータ表示
- [x] app/views/records/edit.html.erbに消化器官編集フォームの作成